### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,5 @@ author=Joan Ortega
 maintainer=Joan Ortega <jomaora@gmail.com>
 sentence=LiquidCrystal Handler library for Arduino
 paragraph=A basic library to handle a LCD screen on Arduino UNO.
-category=IoT
+category=Display
 url=https://github.com/jomaora/LCDHandler.git


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'IoT' in library LCDHandler is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format